### PR TITLE
Fix Cloud Run module error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ moviepy
 python-dotenv
 rich
 whisper
+fastapi
 uvicorn[standard]


### PR DESCRIPTION
## Summary
- install `fastapi`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_687a8d9856b483309f77f186c21d422f