### PR TITLE
Add fastparquet dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ whisper
 pyarrow
 fastapi
 uvicorn[standard]
+fastparquet


### PR DESCRIPTION
## Summary
- add fastparquet to requirements
- verify pyarrow and fastparquet install

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*
- `pip install fastparquet`
- `pip install pyarrow`
- `python - <<'PY'` to check versions

------
https://chatgpt.com/codex/tasks/task_b_687a9736d754832da4fac7cd55418978