### PR TITLE
Fix Dockerfile port config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,5 @@ USER svc
 
 ENV PYTHONUNBUFFERED=1
 ENV DATA_PATH=/data/trendwatch.parquet
-ENV PORT=8000
 
 CMD ["python", "-m", "app.server"]


### PR DESCRIPTION
## Summary
- remove hardcoded `ENV PORT` from Dockerfile

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_687a97420238832db45f1df03ff1f2a8