### PR TITLE
Add fastparquet dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ python-dotenv
 rich
 whisper
 pyarrow
+fastparquet
 fastapi
 uvicorn[standard]


### PR DESCRIPTION
## Summary
- add `fastparquet` to `requirements.txt`

## Testing
- `pytest -q` *(no tests found)*
- `black --check .` *(fails: 2 files would be reformatted)*
- `isort --check-only .` *(fails: imports incorrectly sorted)*
- `docker build -t trendwatch:latest .` *(fails: Cannot connect to the Docker daemon*)

------
https://chatgpt.com/codex/tasks/task_b_687a974223ec832d86512991f8b08230